### PR TITLE
feat: make initial theme mode to system dependent

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:provider/provider.dart';
 import 'package:welcome/pages/about.dart';
 import 'package:welcome/pages/contributors.dart';
@@ -40,7 +41,12 @@ class Welcome extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<ThemeProvider>.value(
-          value: ThemeProvider(lightTheme),
+          value: ThemeProvider(
+            SchedulerBinding.instance!.window.platformBrightness ==
+                    Brightness.light
+                ? lightTheme
+                : darkTheme,
+          ),
           builder: (context, child) => MaterialApp(
             title: 'Welcome',
             theme: theme(context),


### PR DESCRIPTION
Signed-off-by: Ayush P Gupta <ayushpguptaapg@gmail.com>

## Description

This PR aims at making initial brightness to system dependent. Currently, the app always starts with light mode even if we have a system on dark mode.

Relevant ans: https://stackoverflow.com/questions/56304215/how-to-check-if-dark-mode-is-enabled-on-ios-android-using-flutter

Fixes #(issue)

## Screenshots (if appropriate):

System running on dark mode

![Screenshot from 2022-01-08 08-14-17](https://user-images.githubusercontent.com/13887407/148628752-7ff25ae3-6f90-48ce-bb7f-cf6046ece43d.png)


## Type of change

Please tick the relevant option by putting an X inside the bracket

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] All current GitHub actions pass
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document